### PR TITLE
Fix for emoji and few other chars in sms

### DIFF
--- a/char_conv.c
+++ b/char_conv.c
@@ -132,8 +132,17 @@ static ssize_t hexstr_ucs2_to_utf8 (const char* in, size_t in_length, char* out,
 	{
 		return res;
 	}
+	int rlen=out_size;
+	char *ptr=buf;
+	while(rlen>=2){
+		char tmp=*ptr;
+		*ptr=*(ptr+1);
+		*(ptr+1)=tmp;
+		ptr+=2;
+		rlen-=2;
+	}
 
-	res = convert_string (buf, res, out, out_size, "UCS-2BE", "UTF-8");
+	res = convert_string (buf, res, out, out_size, "UTF-16", "UTF-8");
 
 	return res;
 }

--- a/char_conv.c
+++ b/char_conv.c
@@ -132,17 +132,8 @@ static ssize_t hexstr_ucs2_to_utf8 (const char* in, size_t in_length, char* out,
 	{
 		return res;
 	}
-	int rlen=out_size;
-	char *ptr=buf;
-	while(rlen>=2){
-		char tmp=*ptr;
-		*ptr=*(ptr+1);
-		*(ptr+1)=tmp;
-		ptr+=2;
-		rlen-=2;
-	}
 
-	res = convert_string (buf, res, out, out_size, "UTF-16", "UTF-8");
+	res = convert_string (buf, res, out, out_size, "UTF-16BE", "UTF-8");
 
 	return res;
 }


### PR DESCRIPTION
iconv can't convert emoji from UCS-2, but converting without problem from UTF-16.
